### PR TITLE
Add a nuget projectUrl

### DIFF
--- a/ChocolateyTemplate/KinesisTap.nuspec
+++ b/ChocolateyTemplate/KinesisTap.nuspec
@@ -5,8 +5,7 @@
     <version>1.0.0</version>
     <title>KinesisTap (Install)</title>
     <authors>Amazon.com</authors>
-    <!-- projectUrl is required for the community feed -->
-    <!--<projectUrl>https://_Software_Location_REMOVE_OR_FILL_OUT_</projectUrl>-->
+    <projectUrl>https://github.com/awslabs/kinesis-agent-windows</projectUrl>
     <!--<iconUrl>http://cdn.rawgit.com/__REPLACE_YOUR_REPO__/master/icons/ds2agent.png</iconUrl>-->
     <licenseUrl>https://aws.amazon.com/apache-2-0/</licenseUrl>
     <copyright>2017-2018 Amazon.com</copyright>


### PR DESCRIPTION
So consumers of the nuget package can figure out where it came from.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
