### PR TITLE
Make SingleLineJsonParser read log lines with line feed and handle JSON parser exception

### DIFF
--- a/Amazon.KinesisTap.Core.Test/DirectorySourceFactoryTest.cs
+++ b/Amazon.KinesisTap.Core.Test/DirectorySourceFactoryTest.cs
@@ -13,9 +13,7 @@
  * permissions and limitations under the License.
  */
 using System;
-using System.Collections.Generic;
-using System.Text;
-
+using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -29,7 +27,7 @@ namespace Amazon.KinesisTap.Core.Test
             var config = TestUtility.GetConfig("Sources", "JsonLog1");
             string timetampFormat = config["TimestampFormat"];
             string timestampField = config["TimestampField"];
-            IRecordParser parser = new SingleLineJsonParser(timestampField, timetampFormat);
+            IRecordParser parser = new SingleLineJsonParser(timestampField, timetampFormat, NullLogger.Instance);
 
             PluginContext context = new PluginContext(config, null, null);
             var source = DirectorySourceFactory.CreateEventSource(context, parser);

--- a/Amazon.KinesisTap.Core.Test/FileLineReaderTest.cs
+++ b/Amazon.KinesisTap.Core.Test/FileLineReaderTest.cs
@@ -1,0 +1,251 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Amazon.KinesisTap.Core.Test
+{
+    public class FileLineReaderTest
+    {
+        private readonly Encoding _encoding = Encoding.UTF8;
+
+        /// <summary>
+        /// Test situations where a line is not written completely at first.
+        /// </summary>
+        [Fact]
+        public void InterleavedWrites()
+        {
+            var testFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            try
+            {
+                using (var readStream = new FileStream(testFile, FileMode.OpenOrCreate, FileAccess.Read, FileShare.ReadWrite))
+                {
+                    var reader = new FileLineReader();
+                    Assert.Null(reader.ReadLine(readStream, _encoding));
+
+                    // write some text without new line sequence
+                    File.AppendAllText(testFile, new string('*', FileLineReader.MinimumBufferSize - 1));
+
+                    // assert that no line is read yet
+                    Assert.Null(reader.ReadLine(readStream, _encoding));
+
+                    // write line feed
+                    File.AppendAllText(testFile, "\n");
+
+                    // assert that the line is read
+                    Assert.Equal(FileLineReader.MinimumBufferSize - 1, reader.ReadLine(readStream, _encoding).Length);
+                }
+            }
+            finally
+            {
+                File.Delete(testFile);
+            }
+        }
+
+        /// <summary>
+        /// Test that the reader recognizes new line sequences
+        /// </summary>
+        /// <param name="newlineSequence"></param>
+        [Theory]
+        [InlineData("\r")]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public void EmptyLines(string newlineSequence)
+        {
+            var testFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var startString = new string('a', FileLineReader.MinimumBufferSize);
+            var endString = new string('b', FileLineReader.MinimumBufferSize);
+            File.AppendAllText(testFile, startString);
+            try
+            {
+                using (var readStream = new FileStream(testFile, FileMode.OpenOrCreate, FileAccess.Read, FileShare.ReadWrite))
+                {
+                    var reader = new FileLineReader();
+                    Assert.Null(reader.ReadLine(readStream, _encoding));
+                    File.AppendAllText(testFile, newlineSequence);
+                    Assert.Equal(startString, reader.ReadLine(readStream, _encoding));
+
+                    File.AppendAllText(testFile, newlineSequence);
+                    Assert.Equal(string.Empty, reader.ReadLine(readStream, _encoding));
+
+                    File.AppendAllText(testFile, newlineSequence);
+                    Assert.Equal(string.Empty, reader.ReadLine(readStream, _encoding));
+
+                    File.AppendAllText(testFile, endString);
+                    File.AppendAllText(testFile, newlineSequence);
+                    Assert.Equal(endString, reader.ReadLine(readStream, _encoding));
+                }
+            }
+            finally
+            {
+                File.Delete(testFile);
+            }
+        }
+
+        /// <summary>
+        /// Reading multiple consecutive lines in a file.
+        /// </summary>
+        [Theory]
+        [InlineData('a', 2, 10)]
+        [InlineData('b', FileLineReader.MinimumBufferSize - 1, 10)]
+        [InlineData('c', FileLineReader.MinimumBufferSize, 10)]
+        [InlineData('d', FileLineReader.MinimumBufferSize + 1, 200)]
+        [InlineData('d', FileLineReader.MinimumBufferSize * 8, 1000)]
+        public void MultipleLines(char c, int size, int count)
+        {
+            var testFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+            // write all lines to the file
+            for (var i = 0; i < count; i++)
+            {
+                File.AppendAllText(testFile, new string(c, size));
+                File.AppendAllText(testFile, Environment.NewLine);
+            }
+            try
+            {
+                using (var readStream = new FileStream(testFile, FileMode.OpenOrCreate, FileAccess.Read, FileShare.ReadWrite))
+                {
+                    var reader = new FileLineReader();
+                    for (var i = 0; i < count; i++)
+                    {
+                        var line = reader.ReadLine(readStream, _encoding);
+                        if (string.Empty == line)
+                        {
+                            // in the first test case (a,1023,10), due to the internal buffer size, the sequence \r\n might be broken up
+                            // so we just ignore the return values with an empty line
+                            continue;
+                        }
+                        Assert.Equal(new string(c, size), line);
+                    }
+                }
+            }
+            finally
+            {
+                File.Delete(testFile);
+            }
+        }
+
+        /// <summary>
+        /// Test for reading lines longer than the initial buffer size of 1024
+        /// </summary>
+        [Theory]
+        [InlineData(1023)]
+        [InlineData(1024)]
+        [InlineData(1025)]
+        [InlineData(10024)]
+        public void LongLines(int size)
+        {
+            var testFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var reader = new FileLineReader();
+
+            try
+            {
+                using (var readStream = new FileStream(testFile, FileMode.OpenOrCreate, FileAccess.Read, FileShare.ReadWrite))
+                {
+                    for (var i = 0; i < 10; i++)
+                    {
+                        File.AppendAllText(testFile, new string((char)(i + '0'), size));
+                        Assert.Null(reader.ReadLine(readStream, _encoding));
+
+                        File.AppendAllText(testFile, Environment.NewLine);
+                        var line = reader.ReadLine(readStream, _encoding);
+                        Assert.Equal(size, line.Length);
+                    }
+                }
+            }
+            finally
+            {
+                File.Delete(testFile);
+            }
+        }
+
+        /// <summary>
+        /// Make sure we don't just grow the internal buffer indefinitely as data is read.
+        /// </summary>
+        [Theory]
+        [InlineData(FileLineReader.MinimumBufferSize - 2, 10)]
+        [InlineData(FileLineReader.MinimumBufferSize + 2, 10)]
+        [InlineData(FileLineReader.MinimumBufferSize * 2, 1000)]
+        public void BufferIsRealigned(int lineSize, int count)
+        {
+            var random = new Random();
+            var testFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var reader = new FileLineReader();
+
+            try
+            {
+                using (var readStream = new FileStream(testFile, FileMode.OpenOrCreate, FileAccess.Read, FileShare.ReadWrite))
+                {
+                    for (var i = 0; i < count; i++)
+                    {
+                        // write a random string that contains an ASCII
+                        var s = new string((char)(33 + random.Next(90)), lineSize);
+                        File.AppendAllText(testFile, s);
+                        File.AppendAllText(testFile, Environment.NewLine);
+
+                        // read the line
+                        Assert.Equal(s, reader.ReadLine(readStream, _encoding));
+
+                        // make sure that the internal buffer grows as much as twice the record size
+                        Assert.True(reader.InternalBufferSize <= lineSize * 3,
+                            $"Internal buffer size is too large: {reader.InternalBufferSize}");
+                    }
+                }
+            }
+            finally
+            {
+                File.Delete(testFile);
+            }
+        }
+
+        /// <summary>
+        /// Resetting the reader should refresh the state.
+        /// </summary>
+        [Fact]
+        public void ResetReader()
+        {
+            const string testLine = nameof(testLine);
+            var testFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var reader = new FileLineReader();
+
+            try
+            {
+                using (var readStream = new FileStream(testFile, FileMode.OpenOrCreate, FileAccess.Read, FileShare.ReadWrite))
+                {
+                    reader.ReadLine(readStream, _encoding);
+
+                    // write a test line without new line to make the buffer contain data
+                    File.AppendAllText(testFile, testLine);
+                    Assert.Null(reader.ReadLine(readStream, _encoding));
+
+                    // reset
+                    readStream.Seek(0, SeekOrigin.Begin);
+                    reader.Reset();
+
+                    // finish the line and assert
+                    File.AppendAllText(testFile, Environment.NewLine);
+                    Assert.Equal(testLine, reader.ReadLine(readStream, _encoding));
+                }
+            }
+            finally
+            {
+                File.Delete(testFile);
+            }
+        }
+    }
+}

--- a/Amazon.KinesisTap.Core.Test/SingleLineJsonParserTest.cs
+++ b/Amazon.KinesisTap.Core.Test/SingleLineJsonParserTest.cs
@@ -12,12 +12,12 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Xunit;
 
 namespace Amazon.KinesisTap.Core.Test
@@ -25,8 +25,8 @@ namespace Amazon.KinesisTap.Core.Test
     public class SingleLineJsonParserTest
     {
         const string LOG = @"{""ul-log-data"":{""method_name"":""UserProfile"",""module_name"":""ACMEController""},""ul-tag-status"":""INFO"",""ul-timestamp-epoch"":1537519130972, ""Timestamp"":""2018-09-21T08:38:50.972Z""}
-{""ul-log-data"":{""http_url"":""http://acme/org"",""http_request_headers"":{""Accept"":""*/*"",""Accept-Encoding"":""gzip;deflate""},""http_response_code"":401},""ul-tag-status"":""INFO"",""ul-timestamp-epoch"":1537519131241, ""Timestamp"":""2018-09-21T08:38:51.241Z""}";
-
+{""ul-log-data"":{""http_url"":""http://acme/org"",""http_request_headers"":{""Accept"":""*/*"",""Accept-Encoding"":""gzip;deflate""},""http_response_code"":401},""ul-tag-status"":""INFO"",""ul-timestamp-epoch"":1537519131241, ""Timestamp"":""2018-09-21T08:38:51.241Z""}
+";
         [Theory]
         [InlineData("JsonLog1")]
         [InlineData("JsonLog2")]
@@ -47,11 +47,158 @@ namespace Amazon.KinesisTap.Core.Test
             }
         }
 
+        /// <summary>
+        /// Test parsing a log file where lines may not be written completely at first
+        /// </summary>
+        [Fact]
+        public void TestParseInterleavedWrites()
+        {
+            var parser = new SingleLineJsonParser(null, null, NullLogger.Instance);
+            var testFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var context = new LogContext();
+
+            try
+            {
+                var records = ParseFile(parser, testFile, context);
+                Assert.Empty(records);
+
+                File.AppendAllText(testFile, $"{{\"a\":1}}{Environment.NewLine}");
+                records = ParseFile(parser, testFile, context);
+                Assert.Single(records);
+
+                File.AppendAllText(testFile, $"{{\"b\":");
+                records = ParseFile(parser, testFile, context);
+                Assert.Empty(records);
+
+                File.AppendAllText(testFile, $"2}}{Environment.NewLine}");
+                records = ParseFile(parser, testFile, context);
+                Assert.Single(records);
+            }
+            finally
+            {
+                File.Delete(testFile);
+            }
+        }
+
+        /// <summary>
+        /// The parser should ignore invalid JSON.
+        /// </summary>
+        [Fact]
+        public void TestParseInvalidLines()
+        {
+            var parser = new SingleLineJsonParser(null, null, NullLogger.Instance);
+            var testFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var context = new LogContext();
+
+            try
+            {
+                File.AppendAllText(testFile, $"{{\"a\":1}}{Environment.NewLine}");
+                var records = ParseFile(parser, testFile, context);
+                Assert.Single(records);
+
+                // write an in valid json line
+                File.AppendAllText(testFile, $"{{\"b\":");
+                records = ParseFile(parser, testFile, context);
+                Assert.Empty(records);
+
+                File.AppendAllText(testFile, Environment.NewLine);
+                records = ParseFile(parser, testFile, context);
+                Assert.Empty(records);
+
+                File.AppendAllText(testFile, $"{{\"c\":3}}{Environment.NewLine}");
+                records = ParseFile(parser, testFile, context);
+                Assert.Single(records);
+            }
+            finally
+            {
+                File.Delete(testFile);
+            }
+        }
+
+        /// <summary>
+        /// Make sure the parser can handle long records that are not written to the file immediately.
+        /// </summary>
+        [Theory]
+        [InlineData(FileLineReader.MinimumBufferSize)]
+        [InlineData(FileLineReader.MinimumBufferSize * 2)]
+        public void TestParseLongRecords(int size)
+        {
+            var parser = new SingleLineJsonParser(null, null, NullLogger.Instance);
+            var testFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var context = new LogContext();
+
+            var value = new string('a', size);
+
+            try
+            {
+                File.AppendAllText(testFile, $"{{\"a\":\"{value}\"}}{Environment.NewLine}");
+                var records = ParseFile(parser, testFile, context);
+                Assert.Single(records);
+                Assert.Equal(value, (string)records[0].Data["a"]);
+
+                File.AppendAllText(testFile, $"{{\"b\":");
+                records = ParseFile(parser, testFile, context);
+                Assert.Empty(records);
+
+                File.AppendAllText(testFile, $"\"{value}\"}}{Environment.NewLine}");
+                records = ParseFile(parser, testFile, context);
+                Assert.Single(records);
+                Assert.Equal(value, (string)records[0].Data["b"]);
+            }
+            finally
+            {
+                File.Delete(testFile);
+            }
+        }
+
+        /// <summary>
+        /// Make sure that when a file is truncated, the parser is able to detect that.
+        /// </summary>
+        [Fact]
+        public void TestParseTruncatedFile()
+        {
+            var parser = new SingleLineJsonParser(null, null, NullLogger.Instance);
+            var testFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var context = new LogContext();
+
+            var value1 = new string('1', 1024);
+            var value2 = new string('2', 1024);
+            try
+            {
+                File.AppendAllText(testFile, $"{{\"a\":\"{value1}\"}}");
+                var records = ParseFile(parser, testFile, context);
+                Assert.Empty(records);
+
+                File.Delete(testFile);
+                context.Position = 0;
+                File.AppendAllText(testFile, $"{{\"a\":\"{value2}\"}}{Environment.NewLine}");
+
+                records = ParseFile(parser, testFile, context);
+                Assert.Single(records);
+                Assert.Equal(value2, (string)records[0].Data["a"]);
+            }
+            finally
+            {
+                File.Delete(testFile);
+            }
+        }
+
+        private static List<IEnvelope<JObject>> ParseFile(SingleLineJsonParser parser, string file, LogContext context)
+        {
+            using (var readStream = new FileStream(file, FileMode.OpenOrCreate, FileAccess.Read, FileShare.ReadWrite))
+            using (var sr = new StreamReader(readStream))
+            {
+                var records = parser.ParseRecords(sr, context).ToList();
+                context.Position = readStream.Position;
+                return records;
+            }
+        }
+
         private static List<IEnvelope<JObject>> ParseRecords(StreamReader sr, Microsoft.Extensions.Configuration.IConfigurationSection config)
         {
             string timetampFormat = config["TimestampFormat"];
             string timestampField = config["TimestampField"];
-            var parser = new SingleLineJsonParser(timestampField, timetampFormat);
+            var parser = new SingleLineJsonParser(timestampField, timetampFormat, NullLogger.Instance);
             var records = parser.ParseRecords(sr, new DelimitedLogContext()).ToList();
             return records;
         }

--- a/Amazon.KinesisTap.Core/Components/FileLineReader.cs
+++ b/Amazon.KinesisTap.Core/Components/FileLineReader.cs
@@ -1,0 +1,156 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace Amazon.KinesisTap.Core
+{
+    /// <summary>
+    /// Class used to read lines from text files.
+    /// </summary>
+    internal class FileLineReader
+    {
+        private const byte LineFeedByte = (byte)'\n';
+        private const byte CarriageReturnByte = (byte)'\r';
+
+        // make this internal so we can unit-test cases with buffer size boundaries
+        internal const int MinimumBufferSize = 1024;
+
+        private byte[] _buffer = new byte[MinimumBufferSize * 2];
+
+        private int _pos = 0;
+        private int _len = 0;
+
+        // for testing purpose
+        internal int InternalBufferSize => _buffer.Length;
+
+        /// <summary>
+        /// Read the next text line from the stream.
+        /// </summary>
+        /// <param name="stream">The source stream.</param>
+        /// <param name="encoding">The stream's encoding.</param>
+        /// <returns>The next line in the stream, or 'null' if the end of the stream is reached.</returns>
+        /// <remarks>
+        /// Unlike <see cref="StreamReader.ReadLine"/>, this method returns a string only if it is terminated with a new line sequence.
+        /// The class maintains internal buffer, and the <paramref name="stream"/>'s position will be updated as the class reads data.
+        /// Therefore it is important that the class's user maintains the position of the <paramref name="stream"/> between calls to
+        /// <see cref="ReadLine"/> to avoid corrupting the state of the reader.
+        /// </remarks>
+        public string ReadLine(Stream stream, Encoding encoding)
+        {
+            // return any line still in the buffer
+            var line = ParseLineFromBuffer(encoding);
+            if (line != null)
+            {
+                return line;
+            }
+
+            // read the stream into the buffer until we find a new line 
+            int bytesRead;
+            do
+            {
+                var startIdx = _pos + _len;
+                // resize the buffer if neccessary
+                if (_buffer.Length - startIdx < MinimumBufferSize)
+                {
+                    Array.Resize(ref _buffer, _buffer.Length * 2);
+                }
+
+                bytesRead = stream.Read(_buffer, startIdx, MinimumBufferSize);
+                _len += bytesRead;
+
+                line = ParseLineFromBuffer(encoding);
+                if (line != null)
+                {
+                    return line;
+                }
+            } while (bytesRead != 0);
+
+            return null;
+        }
+
+        /// <summary>
+        /// Discard the internal buffer and reset the reader to the initial state.
+        /// </summary>
+        public void Reset()
+        {
+            _pos = 0;
+            _len = 0;
+        }
+
+        /// <summary>
+        /// Look at the internal buffer [_pos, _pos+ _len), parse a complete line, then update the state.
+        /// </summary>
+        /// <returns>A complete line (excluding the new line sequence) or 'null' if no line is detected.</returns>
+        private string ParseLineFromBuffer(Encoding encoding)
+        {
+            if (_len == 0)
+            {
+                return null;
+            }
+
+            var newLineIdx = Array.FindIndex(_buffer, _pos, _len, c => c == LineFeedByte || c == CarriageReturnByte);
+
+            if (newLineIdx < 0)
+            {
+                return null;
+            }
+
+            // found a new line character
+            // form the string
+            var str = newLineIdx == _pos
+            ? string.Empty
+            : encoding.GetString(_buffer, _pos, newLineIdx - _pos);
+
+            // skip over all possible newline sequences
+            switch (_buffer[newLineIdx])
+            {
+                case CarriageReturnByte:
+                    if (newLineIdx + 1 < _pos + _len && _buffer[newLineIdx + 1] == LineFeedByte)
+                    {
+                        // DOS
+                        newLineIdx++;
+                    }
+                    // OSX
+                    break;
+                default:
+                    // UNIX ('\n')
+                    break;
+            }
+
+            _len -= newLineIdx - _pos + 1;
+            _pos = newLineIdx + 1;
+            RealignBuffer();
+            return str;
+        }
+
+        /// <summary>
+        /// If _pos is at the second half of the buffer, move the current data to the buffer's beginning.
+        /// </summary>
+        private void RealignBuffer()
+        {
+            if (_pos < _buffer.Length / 2)
+            {
+                return;
+            }
+
+            Debug.Assert(_len < _buffer.Length / 2);
+            Array.Copy(_buffer, _pos, _buffer, 0, _len);
+            _pos = 0;
+        }
+    }
+}

--- a/Amazon.KinesisTap.Core/Parsers/SingleLineJsonParser.cs
+++ b/Amazon.KinesisTap.Core/Parsers/SingleLineJsonParser.cs
@@ -50,7 +50,7 @@ namespace Amazon.KinesisTap.Core
         public IEnumerable<IEnvelope<JObject>> ParseRecords(StreamReader sr, LogContext context)
         {
             var baseStream = sr.BaseStream;
-            var fileName = (sr.BaseStream as FileStream)?.Name;
+            var fileName = (baseStream as FileStream)?.Name;
             if (context.Position > baseStream.Position)
             {
                 baseStream.Position = context.Position;
@@ -97,16 +97,13 @@ namespace Amazon.KinesisTap.Core
                     // this means that the line is not a valid JSON, skip and read next line
                     continue;
                 }
-                else
-                {
-                    yield return new LogEnvelope<JObject>(jObject,
+
+                yield return new LogEnvelope<JObject>(jObject,
                        _getTimestamp(jObject),
                        line,
                        context.FilePath,
                        context.Position,
                        context.LineNumber);
-                }
-
             } while (line != null);
         }
     }

--- a/Amazon.KinesisTap.Core/Sources/DirectorySource.cs
+++ b/Amazon.KinesisTap.Core/Sources/DirectorySource.cs
@@ -469,19 +469,21 @@ namespace Amazon.KinesisTap.Core
                     foreach (var record in records)
                     {
                         ILogEnvelope envelope = (ILogEnvelope)record;
-                        if (record.Timestamp > (this.InitialPositionTimestamp ?? DateTime.MinValue) && envelope.LineNumber > _skipLines)
+                        if (envelope != null
+                            && record.Timestamp > (this.InitialPositionTimestamp ?? DateTime.MinValue)
+                            && envelope.LineNumber > _skipLines)
                         {
                             record.BookmarkId = bookmarkId;
                             _recordSubject.OnNext(record);
                             recordsRead++;
                         }
 
-                        //Need to grab the position before disposing the reader because disposing the reader will dispose the stream
-                        bytesRead = sr.BaseStream.Position - sourceInfo.Position;
-                        sourceInfo.Position = sr.BaseStream.Position;
-
                         if (!_started) break;
                     }
+
+                    //Need to grab the position before disposing the reader because disposing the reader will dispose the stream
+                    bytesRead = fs.Position - sourceInfo.Position;
+                    sourceInfo.Position = fs.Position;
                     sourceInfo.ConsecutiveIOExceptionCount = 0;
                 }
             }

--- a/Amazon.KinesisTap.Core/Sources/DirectorySourceFactory.cs
+++ b/Amazon.KinesisTap.Core/Sources/DirectorySourceFactory.cs
@@ -13,10 +13,8 @@
  * permissions and limitations under the License.
  */
 using System;
-using System.IO;
 using System.Linq;
 using System.Reflection;
-
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -80,7 +78,7 @@ namespace Amazon.KinesisTap.Core
                             return CreateEventSourceWithDelimitedLogParser(context, timetampFormat, timeZoneKind);
                         case "singlelinejson":
                             return CreateEventSource(context,
-                                new SingleLineJsonParser(timestampField, timetampFormat));
+                                new SingleLineJsonParser(timestampField, timetampFormat, logger));
                         default:
                             IFactoryCatalog<IRecordParser> parserFactories =
                                 context?.ContextData?[PluginContext.PARSER_FACTORIES] as IFactoryCatalog<IRecordParser>;

--- a/Amazon.KinesisTap.ParserExamples/ExampleParserFactory.cs
+++ b/Amazon.KinesisTap.ParserExamples/ExampleParserFactory.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 using Amazon.KinesisTap.Core;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Amazon.KinesisTap.ParserExamples
 {
@@ -55,7 +56,7 @@ namespace Amazon.KinesisTap.ParserExamples
             switch (entry.ToLower())
             {
                 case SINGLE_LINE_JSON2:
-                    return new SingleLineJsonParser(timestampField, timetampFormat);
+                    return new SingleLineJsonParser(timestampField, timetampFormat, NullLogger.Instance);
                 default:
                     throw new ArgumentException($"Parser {entry} not recognized.");
             }


### PR DESCRIPTION
### Description
This PR fixes several issues regarding `SingleLineJsonParser`:
* Currently, if there is a log record that is invalid JSON, the parser is not able to handle the parsing Exception and `DirectorySource` is not able to update the log file's position. As a result, the agent will keep reading the same record and failling over and over again. This PR catches the Exception, log the error message, and skip the invalid record.
* Some customers write log records larger than NLog's buffer size (1024), and so a record line may not be written completely at once. (e.g. NLog writes `{"key":` first, then write the rest `"value"}` after a while. When that happens, Kinesis agent thinks that `{"key":` is the entire record and fails, because the `SingleLineJsonParser` uses `StreamReader.ReadLine()`, which returns a string when `EndOfStream` is reached EVEN IF there is no new line sequence. This PR adds a new class `FileLineReader`, which returns a line ONLY IF it ends with a new line sequence. This allows `SingleLineJsonParser` to always parse the complete JSON record line.

### Testing
Added 2 new sets of tests: `FileLineReaderTest` to test the behavior of `FileLineReader`, and `SingleLineJsonParserTest` to test the behavior of `SingleLineJsonParser` using the new `ReadLine` functionality.