### PR TITLE
By default do not include uniqueid in windows event log

### DIFF
--- a/Amazon.KinesisTap.Windows/EventRecordEnvelope.cs
+++ b/Amazon.KinesisTap.Windows/EventRecordEnvelope.cs
@@ -41,7 +41,7 @@ namespace Amazon.KinesisTap.Windows
 
         public override string ToString()
         {
-            return $"[{Environment.GetEnvironmentVariable(ConfigConstants.UNIQUE_CLIENT_ID)}] [{_data.LogName}] [{_data.LevelDisplayName}] [{_data.EventId}] [{_data.ProviderName}] [{ _data.MachineName}] [{_data.Description}]";
+            return $"[{_data.LogName}] [{_data.LevelDisplayName}] [{_data.EventId}] [{_data.ProviderName}] [{ _data.MachineName}] [{_data.Description}]";
         }
 
         public override string GetMessage(string format)


### PR DESCRIPTION
*Issue #, NA*

*Description of changes:*
By default do not include uniqueid in windows event log


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
