### PR TITLE
Configure logging after hosting configuration

### DIFF
--- a/Amazon.KinesisTap.Hosting/KinesisTapHostBuilder.cs
+++ b/Amazon.KinesisTap.Hosting/KinesisTapHostBuilder.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License").
@@ -68,8 +68,14 @@ namespace Amazon.KinesisTap.Hosting
                         => new KinesisTapMetricsSource("_KinesisTapMetricsSource", services.GetService<ILogger<IMetrics>>()));
                     services.AddSingleton<ISessionFactory, DefaultSessionFactory>();
                     services.AddHostedService<Worker>();
-                })
-                .ConfigureLogging(logging =>
+                });
+
+            return builder;
+        }
+
+        public static void ConfigureDefaultLogging(this IHostBuilder hostBuilder)
+        {
+            hostBuilder.ConfigureLogging(logging =>
                 {
                     // this is important so that NLog does not stop logging when SIGTERM is catched
                     NLog.LogManager.AutoShutdown = false;
@@ -88,8 +94,6 @@ namespace Amazon.KinesisTap.Hosting
 #endif
                         .AddNLog(nlogPath);
                 });
-
-            return builder;
         }
 
         private static void SetComputerNameEnvironmentVariable()

--- a/Amazon.KinesisTap/Program.cs
+++ b/Amazon.KinesisTap/Program.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License").
@@ -26,6 +26,7 @@ namespace Amazon.KinesisTap
         {
             var builder = KinesisTapHostBuilder.Create(args);
             builder.UseWindowsService();
+            builder.ConfigureDefaultLogging();
 
             builder.Build().Run();
         }


### PR DESCRIPTION
*Description of changes:*
The UseWindowsService method adds logging to Windows Event Log, which is not desired by KinesisTap.

We need to re-configure logging after this function is called. The new ConfigureDefaultLogging overwrites the logging configuration (to using NLog).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
